### PR TITLE
Bugfix for Metadata handling

### DIFF
--- a/condor_git_config.py
+++ b/condor_git_config.py
@@ -97,7 +97,7 @@ class ConfigCache(object):
         self.cache_path = cache_path
         self.max_age = max_age
         self._work_path = os.path.abspath(os.path.join(cache_path, branch))
-        self._meta_file = self.abspath('.cache.ast')
+        self._meta_file = self.abspath('cache.json')
         self._cache_lock = filelock.FileLock(
             os.path.join('/tmp', '.cache.%s.lock' % zlib.adler32(os.path.basename(__file__).encode()))
         )
@@ -118,8 +118,8 @@ class ConfigCache(object):
         return False
 
     def __iter__(self):
-        # avoid duplicates from links, and exclude our own internal files
-        seen = {'.cache.ast'}
+        # avoid duplicates from links
+        seen = set()
         repo_path = self.repo_path()
         for dir_path, dir_names, file_names in os.walk(repo_path):
             if '.git' in dir_names:
@@ -148,7 +148,7 @@ class ConfigCache(object):
 
     def _update_metadata(self):
         with open(self._meta_file, 'w') as raw_meta:
-            raw_meta.write({'git_uri': self.git_uri, 'branch': self.branch, 'timestamp': time.time()})
+            json.dump({'git_uri': self.git_uri, 'branch': self.branch, 'timestamp': time.time()}, raw_meta)
 
     def refresh(self):
         if not self.outdated:
@@ -167,6 +167,7 @@ class ConfigCache(object):
                 cwd=repo_path,
                 universal_newlines=True
             )
+        self._update_metadata()
 
 
 class ConfigSelector(object):

--- a/condor_git_config.py
+++ b/condor_git_config.py
@@ -5,7 +5,7 @@ import argparse
 import logging
 import subprocess
 import time
-import ast
+import json
 import functools
 import re
 import random
@@ -96,14 +96,15 @@ class ConfigCache(object):
         self.branch = branch
         self.cache_path = cache_path
         self.max_age = max_age
-        self._meta_file = self._abspath('.cache.ast')
+        self._work_path = os.path.abspath(os.path.join(cache_path, branch))
+        self._meta_file = self.abspath('.cache.ast')
         self._cache_lock = filelock.FileLock(
             os.path.join('/tmp', '.cache.%s.lock' % zlib.adler32(os.path.basename(__file__).encode()))
         )
-        os.makedirs(self.cache_path, exist_ok=True, mode=0o755)
+        os.makedirs(self._work_path, exist_ok=True, mode=0o755)
 
-    def _abspath(self, *rel_paths):
-        return os.path.abspath(os.path.join(self.cache_path, *rel_paths))
+    def abspath(self, *rel_paths):
+        return os.path.abspath(os.path.join(self._work_path, *rel_paths))
 
     def __enter__(self):
         self._cache_lock.acquire()
@@ -116,12 +117,12 @@ class ConfigCache(object):
     def __iter__(self):
         # avoid duplicates from links, and exclude our own internal files
         seen = {'.cache.ast'}
-        for dir_path, dir_names, file_names in os.walk(self.cache_path):
+        for dir_path, dir_names, file_names in os.walk(self._work_path):
             if '.git' in dir_names:
                 dir_names.remove('.git')
             dir_names[:] = sorted(dir_names)
             for file_name in sorted(file_names):
-                rel_path = os.path.normpath(os.path.relpath(os.path.join(dir_path, file_name), self.cache_path))
+                rel_path = os.path.normpath(os.path.relpath(os.path.join(dir_path, file_name), self._work_path))
                 if rel_path in seen:
                     continue
                 seen.add(rel_path)
@@ -131,7 +132,7 @@ class ConfigCache(object):
     def outdated(self):
         try:
             with open(self._meta_file, 'r') as raw_meta:
-                meta_data = ast.literal_eval(''.join(raw_meta))
+                meta_data = json.load(raw_meta)
         except FileNotFoundError:
             return True
         else:
@@ -148,18 +149,18 @@ class ConfigCache(object):
     def refresh(self):
         if not self.outdated:
             return
-        if not os.path.exists(os.path.join(self.cache_path, '.git')):
+        if not os.path.exists(os.path.join(self._work_path, '.git')):
             subprocess.check_output(
-                ['git', 'clone', '--quiet', '--branch', str(self.branch), str(self.git_uri), str(self.cache_path)],
+                ['git', 'clone', '--quiet', '--branch', str(self.branch), str(self.git_uri), str(self._work_path)],
                 timeout=30,
-                cwd=self.cache_path,
+                cwd=self._work_path,
                 universal_newlines=True,
             )
         else:
             subprocess.check_output(
                 ['git', 'pull'],
                 timeout=30,
-                cwd=self.cache_path,
+                cwd=self._work_path,
                 universal_newlines=True
             )
 
@@ -186,7 +187,7 @@ class ConfigSelector(object):
                 continue
             if self.pattern.search(rel_path):
                 if not self.blacklist.search(rel_path) or self.whitelist.search(rel_path):
-                    yield os.path.join(config_cache.cache_path, rel_path)
+                    yield config_cache.abspath(rel_path)
 
 
 def include_configs(path_key, config_cache, config_selector, destination=sys.stdout):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ repo_base_dir = os.path.abspath(os.path.dirname(__file__))
 # pull in the packages metadata
 package_about = {
     '__title__': 'condor_git_config',
-    '__version__': '0.1.0',
+    '__version__': '0.1.1',
     '__summary__': 'dynamically configure an HTCondor node from a git repository',
     '__author__': 'Max Fischer',
     '__email__': 'maxfischer2781@gmail.com',


### PR DESCRIPTION
This PR fixes the handling of metadata by the cache.

- separate location for metadata and checked out content
- same cache path can be used for separate repo branches
- metadata is written as JSON, not a Python literal 😨 
- **cache age and staleness is properly tracked** ⚠️ 